### PR TITLE
crosslinks: Only link existing tiddlers

### DIFF
--- a/src/plugins/crosslinks/ui/ViewTemplate/footer.tid
+++ b/src/plugins/crosslinks/ui/ViewTemplate/footer.tid
@@ -9,15 +9,15 @@ description: Adds a footer to all non-system tiddlers showing the tiddler's link
   <$list filter=<<crosslinks.filter-has-links>> variable=noop>
     <$vars stateTiddler=<<qualify "$:/state/plugins/benwebber/crosslinks">>>
       <div class={{{ [all[current]get[crosslinks.class]] crosslinks tw-border-solid tw-border-t tw-border-x-0 tw-border-b-0 tw-py-2 +[!is[blank]join[ ]] }}}>
-        <$list filter="[<stateTiddler>is[tiddler]]" variable=noop>
+        <$list filter="[<stateTiddler>is[tiddler]has:field[text]]" variable=noop>
           <$button actions=<<crosslinks.toggle>> class="tc-btn-invisible crosslinks-button crosslinks-button-active tw-align-middle tw-font-bold">
             {{$:/core/images/down-arrow}} Links
           </$button>
           <$list filter="[all[current]links[]then<currentTiddler>first[]]">
             <h4 class="tw-my-2">References</h4>
-            <<list-links filter:"[title<currentTiddler>links[]]" type:"ol" class:"tw-m-0">>
+            <<list-links filter:"[title<currentTiddler>links[]has:field[text]]" type:"ol" class:"tw-m-0">>
           </$list>
-          <$list filter="[all[current]backlinks[]then<currentTiddler>first[]]">
+          <$list filter="[all[current]backlinks[]has:field[text]then<currentTiddler>first[]]">
             <h4 class="tw-my-2">Citations</h4>
             <<list-links filter:"[title<currentTiddler>backlinks[]!is[draft]sort[]]" type:"ol" class:"tw-m-0">>
           </$list>


### PR DESCRIPTION
When autolinking CamelCase, the current version displays all CamelCase text detected in the current tiddler in its reference section, whether this matches an existing tiddler or not. This proposed change adds an existence test to avoid referencing empty tiddlers.